### PR TITLE
Change the Fundamental Identifier of Viewers

### DIFF
--- a/server/services/twitch.js
+++ b/server/services/twitch.js
@@ -59,7 +59,7 @@ const strategy = new TwitchStrategy(
 		await verifyToken(accessToken)
 		cb(undefined, {
 			id: profile.id,
-			name: profile.display_name,
+			name: profile.login,
 			picture: profile.profile_image_url,
 			service: 'twitch',
 		})


### PR DESCRIPTION
Using the Displayname as a Identifier clashes with Twitchtoolkit and creates a second user for any user which "login/username" doesn't match their "displayname" allowing them to basically duplicate their coingain and amount of pawns they can control with just one account. which can be abused and is a straight up inconvenience for people not abusing it.